### PR TITLE
Update the documentation.

### DIFF
--- a/src/manager/Bantorra.ml
+++ b/src/manager/Bantorra.ml
@@ -99,7 +99,7 @@
 
     If the [deps] field is missing, then the library has no dependencies. Each dependency is specified by its mount point ([mount_point]), the name of the router to find the imported library ([router]), and the argument to the router ([router_argument]). During the resolution, the entire JSON subtree under the field [router_argument] is passed to the router. See {!type:Router.router_argument} and {!val:Router.make}.
 
-    The order of entries in [dep] does not matter because the dispatching is based on longest prefix match. If no match can be found, then it means the unit path refers to a local unit. The same library can be mounted at multiple points. However, to keep the resolution unambiguous, there cannot be two libraries mounted at the same point, and the mount point cannot be the empty list (the root). Here is an example demonstrating the longest prefix match:
+    The order of entries in [dep] does not matter because the dispatching is based on longest prefix match. If no match can be found, then it means the unit path refers to a local unit. The same library can be mounted at multiple points. However, to keep the resolution unambiguous, there cannot be two libraries mounted at the same point. Here is an example demonstrating the longest prefix match:
     {v
 {
   "format": "1.0.0",


### PR DESCRIPTION
It should now be possible to mount a library at the root. If not, it is a bug! Originally, mounting at the root was intended to be banned (because the mounted library will shadow all units in the original library), but this turns out to be a useful and simple way to implement aliasing.